### PR TITLE
Fix incoherence with String isEmpty Rule

### DIFF
--- a/extra-rules/src/main/scala/io.tabmo.circe.extra.rules/StringRules.scala
+++ b/extra-rules/src/main/scala/io.tabmo.circe.extra.rules/StringRules.scala
@@ -27,7 +27,7 @@ object StringRules extends GenericRules {
   def minLength(minLength: Int, errorCode: String = "error.minimum.length"): Rule[String, String] =
     validateWith[String](errorCode)(_.length > minLength)
 
-  def isEmpty(errorCode: String = "error.is.empty"): Rule[String, String] =
+  def isNotEmpty(errorCode: String = "error.is.not.empty"): Rule[String, String] =
     validateWith[String](errorCode)(!_.isEmpty)
 
   def notBlank(errorCode: String = "error.blank") =

--- a/extra-rules/src/test/scala/rules/StringRulesSpec.scala
+++ b/extra-rules/src/test/scala/rules/StringRulesSpec.scala
@@ -39,16 +39,16 @@ class StringRulesSpec extends RulesSpec {
       }
     }
 
-    "a isEmpty rule" should {
+    "a isNotEmpty rule" should {
 
       "accept a String doesn't empty" in {
         forAll(Gen.alphaStr.filter(_.length != 0)) { str =>
-          executeRule(StringRules.isEmpty(), str) should ===(Valid(str))
+          executeRule(StringRules.isNotEmpty(), str) should ===(Valid(str))
         }
       }
 
       "reject a String with an upper-sized cod" in {
-        executeRule(StringRules.isEmpty(), "") should ===(generateRuleError("error.is.empty"))
+        executeRule(StringRules.isNotEmpty(), "") should ===(generateRuleError("error.is.not.empty"))
       }
     }
 


### PR DESCRIPTION
We find some incoherence with the `isEmpty()` Rule in StringRules. 
We were checking if the method isEmpty was not empty but return *isEmpty* error and method's name.