### PR TITLE
Added min & max values to argument of ValidationError

### DIFF
--- a/core/src/main/scala/io/tabmo/json/rules/GenericRules.scala
+++ b/core/src/main/scala/io/tabmo/json/rules/GenericRules.scala
@@ -5,7 +5,7 @@ import cats.data.Validated.{Invalid, Valid}
 import scala.util.matching.Regex
 
 trait GenericRules {
-  def validateWith[I](error: String, args: String*)(f: I => Boolean): Rule[I, I] = { Rule[I, I](v => {
+  def validateWith[I](error: String, args: Any*)(f: I => Boolean): Rule[I, I] = { Rule[I, I](v => {
       if (f(v)) Valid(v)
       else Invalid(ValidationError(error, args: _*))
     })

--- a/core/src/main/scala/io/tabmo/json/rules/ValidationError.scala
+++ b/core/src/main/scala/io/tabmo/json/rules/ValidationError.scala
@@ -1,13 +1,13 @@
 package io.tabmo.json.rules
 
 
-case class ValidationError(message: String, args: String*) {
+case class ValidationError(message: String, args: Any*) {
   def toError: String =
-    (message :: args.toList).mkString("//")
+    (message :: args.map(_.toString).toList).mkString("//")
 }
 
 object ValidationError {
-  def apply(message: String, args: String*) =
+  def apply(message: String, args: Any*) =
     new ValidationError(message, args: _*)
 }
 

--- a/extra-rules/src/main/scala/io.tabmo.circe.extra.rules/BigDecimalRules.scala
+++ b/extra-rules/src/main/scala/io.tabmo.circe.extra.rules/BigDecimalRules.scala
@@ -11,10 +11,10 @@ object BigDecimalRules extends GenericRules {
     validateWith[BigDecimal](errorCode)(n => num.gt(n, num.zero))
 
   def max(max: BigDecimal, errorCode: String = "error.max.size"): Rule[BigDecimal, BigDecimal] =
-    validateWith[BigDecimal](errorCode)(_ <= max)
+    validateWith[BigDecimal](errorCode, max)(_ <= max)
 
   def min(min: BigDecimal, errorCode: String = "error.min.size"): Rule[BigDecimal, BigDecimal] =
-    validateWith[BigDecimal](errorCode)(_ >= min)
+    validateWith[BigDecimal](errorCode, min)(_ >= min)
 
   def scaleDecimal(nb: Int, roundingMode: BigDecimal.RoundingMode.RoundingMode = RoundingMode.HALF_UP): Rule[BigDecimal, BigDecimal] = Rule[BigDecimal, BigDecimal] { n =>
     Valid(n.setScale(nb, roundingMode))

--- a/extra-rules/src/main/scala/io.tabmo.circe.extra.rules/IntRules.scala
+++ b/extra-rules/src/main/scala/io.tabmo.circe.extra.rules/IntRules.scala
@@ -8,9 +8,9 @@ object IntRules extends GenericRules {
     validateWith[Int](errorCode)(n => num.gt(n, num.zero))
 
   def max(max: Int, errorCode: String = "error.max.size"): Rule[Int, Int] =
-    validateWith[Int](errorCode)(_ <= max)
+    validateWith[Int](errorCode, max)(_ <= max)
 
   def min(min: Int, errorCode: String = "error.min.size"): Rule[Int, Int] =
-    validateWith[Int](errorCode)(_ >= min)
+    validateWith[Int](errorCode, min)(_ >= min)
 
 }

--- a/extra-rules/src/main/scala/io.tabmo.circe.extra.rules/StringRules.scala
+++ b/extra-rules/src/main/scala/io.tabmo.circe.extra.rules/StringRules.scala
@@ -19,13 +19,13 @@ object StringRules extends GenericRules {
   def url(error: String) = pattern(patternUrl, error)
 
   def length(size: Int, errorCode: String = "error.length"): Rule[String, String] =
-    validateWith[String](errorCode)(_.length == size)
+    validateWith[String](errorCode, size)(_.length == size)
 
   def maxLength(maxLength: Int, errorCode: String = "error.maximum.length"): Rule[String, String] =
-    validateWith[String](errorCode)(_.length <= maxLength)
+    validateWith[String](errorCode, maxLength)(_.length <= maxLength)
 
   def minLength(minLength: Int, errorCode: String = "error.minimum.length"): Rule[String, String] =
-    validateWith[String](errorCode)(_.length >= minLength)
+    validateWith[String](errorCode, minLength)(_.length >= minLength)
 
   def isNotEmpty(errorCode: String = "error.is.not.empty"): Rule[String, String] =
     validateWith[String](errorCode)(!_.isEmpty)

--- a/extra-rules/src/test/scala/rules/BigDecimalRulesSpec.scala
+++ b/extra-rules/src/test/scala/rules/BigDecimalRulesSpec.scala
@@ -35,7 +35,7 @@ class BigDecimalRulesSpec extends RulesSpec with ScalaCheckPropertyChecks {
 
       "reject an BigDecimal which is under the maximum value" in {
         forAll(genBigDecimal(2, 49)) { value =>
-          executeRule(BigDecimalRules.max(BigDecimal(1.0)), value) should ===(generateRuleError("error.max.size"))
+          executeRule(BigDecimalRules.max(BigDecimal(1.0)), value) should ===(generateRuleError("error.max.size", BigDecimal(1.0)))
         }
       }
     }
@@ -50,7 +50,7 @@ class BigDecimalRulesSpec extends RulesSpec with ScalaCheckPropertyChecks {
 
       "reject an Int which is upper the minimum value" in {
         forAll(genBigDecimal(1, 50)) { value =>
-          executeRule(BigDecimalRules.min(BigDecimal(51.0)), value) should ===(generateRuleError("error.min.size"))
+          executeRule(BigDecimalRules.min(BigDecimal(51.0)), value) should ===(generateRuleError("error.min.size", BigDecimal(51.0)))
         }
       }
     }

--- a/extra-rules/src/test/scala/rules/IntRulesSpec.scala
+++ b/extra-rules/src/test/scala/rules/IntRulesSpec.scala
@@ -33,7 +33,7 @@ class IntRulesSpec extends RulesSpec with ScalaCheckPropertyChecks {
 
       "reject an Int which is under the maximum value" in {
         forAll(Gen.chooseNum(2, 50)) { value =>
-          executeRule(IntRules.max(1), value) should ===(generateRuleError("error.max.size"))
+          executeRule(IntRules.max(1), value) should ===(generateRuleError("error.max.size", 1))
         }
       }
     }
@@ -48,7 +48,7 @@ class IntRulesSpec extends RulesSpec with ScalaCheckPropertyChecks {
 
       "reject an Int which is upper the minimum value" in {
         forAll(Gen.chooseNum(1, 50)) { value =>
-          executeRule(IntRules.min(51), value) should ===(generateRuleError("error.min.size"))
+          executeRule(IntRules.min(51), value) should ===(generateRuleError("error.min.size", 51))
         }
       }
     }

--- a/extra-rules/src/test/scala/rules/RulesSpec.scala
+++ b/extra-rules/src/test/scala/rules/RulesSpec.scala
@@ -7,5 +7,5 @@ import org.scalatest.matchers.should.Matchers
 
 trait RulesSpec extends AnyWordSpec with Matchers {
   def executeRule[I, O](r: Rule[I, O], value: I) = r.rule.apply(value)
-  def generateRuleError(error: String, args: String*) = Invalid(ValidationError(error, args: _*))
+  def generateRuleError(error: String, args: Any*) = Invalid(ValidationError(error, args: _*))
 }

--- a/extra-rules/src/test/scala/rules/StringRulesSpec.scala
+++ b/extra-rules/src/test/scala/rules/StringRulesSpec.scala
@@ -20,7 +20,7 @@ class StringRulesSpec extends RulesSpec with ScalaCheckPropertyChecks {
 
       "reject a String with an under-sized cod" in {
         forAll(Gen.alphaStr.filter(_.length < 40)) {str =>
-          executeRule(StringRules.minLength(40), str) should ===(generateRuleError("error.minimum.length"))
+          executeRule(StringRules.minLength(40), str) should ===(generateRuleError("error.minimum.length", 40))
         }
       }
     }
@@ -35,7 +35,7 @@ class StringRulesSpec extends RulesSpec with ScalaCheckPropertyChecks {
 
       "reject a String with an upper-sized cod" in {
         forAll(Gen.alphaStr.filter(_.length > 40)) { str =>
-          executeRule(StringRules.maxLength(40), str) should ===(generateRuleError("error.maximum.length"))
+          executeRule(StringRules.maxLength(40), str) should ===(generateRuleError("error.maximum.length", 40))
         }
       }
     }
@@ -63,7 +63,7 @@ class StringRulesSpec extends RulesSpec with ScalaCheckPropertyChecks {
 
       "reject a String with a bad size" in {
         forAll(Gen.alphaStr) { str =>
-          executeRule(StringRules.length(str.length + 1), str) should ===(generateRuleError("error.length"))
+          executeRule(StringRules.length(str.length + 1), str) should ===(generateRuleError("error.length", str.length + 1))
         }
       }
     }


### PR DESCRIPTION
Hi, thank you for your useful library.

I want to use the configured value `n` for error messages, like `IntRuls.min(n)` or `StringRules.maxLength(n)`.

For example, when I define a rule like this,

```
StringRules.maxLength(100)
```

I expect such an instance to be created on validation error.

```
Invalid(ValidationError("error.maximum.length", 100))
```

Also, define the key and placeholder of the error message as follows,

```
error.maximum.length = Maximum length is {0}
```

And I want to create an error message based on the returned key and the value passed to the rule.

```
Maximum length is 100
```

However, currently, `n` is not included and the return value is as follows.

```
Invalid(ValidationError("error.maximum.length"))
```

This pull request fixed that problem.

Thank you.